### PR TITLE
Fix random crashes

### DIFF
--- a/core/main.cpp
+++ b/core/main.cpp
@@ -14,10 +14,10 @@ DWORD WINAPI initialize(void* instance) {
 
 	try {
 		interfaces::initialize();
-		hooks::initialize();
 		fgui_input::initialize();
 		fgui_renderer::initialize();
 		gui::initialize();
+		hooks::initialize();
 		render::setup();
 	}
 


### PR DESCRIPTION
Fixed random crashes due to elements not being initialized when trying to use library elements on hooks/functions.