### PR TITLE
Tidy up engine prediction, make hooks static.

### DIFF
--- a/core/features/misc/engine_prediction.cpp
+++ b/core/features/misc/engine_prediction.cpp
@@ -1,10 +1,5 @@
 #include "engine_prediction.hpp"
 
-player_move_data data;
-float old_cur_time;
-float old_frame_time;
-int* prediction_random_seed;
-
 void prediction::start(c_usercmd* cmd) {
 	if (!csgo::local_player)
 		return;

--- a/core/features/misc/engine_prediction.hpp
+++ b/core/features/misc/engine_prediction.hpp
@@ -1,7 +1,12 @@
 #pragma once
-#include "../../../dependencies/common_includes.hpp"
+#include "../../../dependencies/utilities/csgo.hpp"
 
 namespace prediction {
 	void start(c_usercmd* cmd);
 	void end();
+
+	inline player_move_data data;
+	inline float old_cur_time;
+	inline float old_frame_time;
+	inline int* prediction_random_seed;
 };

--- a/core/hooks/hooks.hpp
+++ b/core/hooks/hooks.hpp
@@ -6,12 +6,12 @@ namespace hooks {
 
 	namespace create_move {
 		using fn = bool(__stdcall*)(float, c_usercmd*);
-		bool __fastcall hook(void* ecx, void* edx, int input_sample_frametime, c_usercmd* cmd);
+		static bool __fastcall hook(void* ecx, void* edx, int input_sample_frametime, c_usercmd* cmd);
 	};
 
 	namespace paint_traverse {
 		using fn = void(__thiscall*)(i_panel*, unsigned int, bool, bool);
-		void __stdcall hook(unsigned int panel, bool force_repaint, bool allow_force);
+		static void __stdcall hook(unsigned int panel, bool force_repaint, bool allow_force);
 	}
 
 }


### PR DESCRIPTION
There's no reason whatsoever NOT to make hooks static, it's a performance improvement, and I have "tidied up" engine prediction by using the actual namespace to declare the variables it requires, so it's not just laying around, somewhere, in a random scope.