### PR TITLE
Fixed uninject w/ menu open!

### DIFF
--- a/core/main.cpp
+++ b/core/main.cpp
@@ -22,6 +22,11 @@ unsigned long WINAPI initialize(void* instance) {
 
 	while (!GetAsyncKeyState(VK_END))
 		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	
+	//close menu so input is restored to user in the hooks::paint_traverse::hook hook.
+	variables::menu::opened = false;
+	//wait for paint_traverse::hook to be called and restore input.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	FreeLibraryAndExitThread(static_cast<HMODULE>(instance), 0);
 }


### PR DESCRIPTION
When using the current build, if you uninject with the menu open - your input will be broken (no keyboard/mouse input due to the painttraverse hook not giving you control back).
By closing the menu upon uninjection & waiting 50ms for painttraverse to be called again, the painttraverse hook will restore your input access again after uninjection.